### PR TITLE
Restore SASS Validation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,5 @@ script:
 - pip3 install --upgrade setuptools pip
 - pip3 install yamllint
 - yamllint docassemble/jcc/abilitytopay/data/questions
-deploy:
-  provider: pypi
-  user: "$PYPI_USER"
-  password: "$PYPI_SECRET"
+- npm install bootstrap sass
+- npx sass source/style.scss docassemble/jcc/abilitytopay/data/static/style.css


### PR DESCRIPTION
And remove deploy code, it can be restored by you when the JCC has a PyPi account