### PR TITLE
alternate find for IE - 11

### DIFF
--- a/docassemble/jcc/abilitytopay/data/questions/interview.yml
+++ b/docassemble/jcc/abilitytopay/data/questions/interview.yml
@@ -12,29 +12,7 @@ features:
     - a2p.js
     - version.js
     - chatbot.js
-    - polyfillalt.jsmodules:
-    - docassemble.base.util
-    - docassemble.jcc.abilitytopay.a2papi
-    - docassemble.jcc.abilitytopay.translations
-    - docassemble.jcc.abilitytopay.templates
-    ---
-    features:
-      bootstrap theme: style.css
-      progress bar: True
-      javascript:
-        - includes-prototype.js
-        - a2p.js
-        - version.js
-        - chatbot.js
-        - polyfillalt.js
-    ---
-    metadata:
-      title: Ability to Pay
-    ---
-    include:
-      - language-setup.yml
-      - chatbot.yml
-      - questions.yml
+    - polyfillalt.js
 
 ---
 metadata:

--- a/docassemble/jcc/abilitytopay/data/questions/interview.yml
+++ b/docassemble/jcc/abilitytopay/data/questions/interview.yml
@@ -12,6 +12,30 @@ features:
     - a2p.js
     - version.js
     - chatbot.js
+    - polyfillalt.jsmodules:
+    - docassemble.base.util
+    - docassemble.jcc.abilitytopay.a2papi
+    - docassemble.jcc.abilitytopay.translations
+    - docassemble.jcc.abilitytopay.templates
+    ---
+    features:
+      bootstrap theme: style.css
+      progress bar: True
+      javascript:
+        - includes-prototype.js
+        - a2p.js
+        - version.js
+        - chatbot.js
+        - polyfillalt.js
+    ---
+    metadata:
+      title: Ability to Pay
+    ---
+    include:
+      - language-setup.yml
+      - chatbot.yml
+      - questions.yml
+
 ---
 metadata:
   title: Ability to Pay

--- a/docassemble/jcc/abilitytopay/data/static/polyfillalt.js
+++ b/docassemble/jcc/abilitytopay/data/static/polyfillalt.js
@@ -1,0 +1,46 @@
+// https://tc39.github.io/ecma262/#sec-array.prototype.find
+if (!Array.prototype.find) {
+  Object.defineProperty(Array.prototype, 'find', {
+    value: function(predicate) {
+      // 1. Let O be ? ToObject(this value).
+      if (this == null) {
+        throw TypeError('"this" is null or not defined');
+      }
+
+      var o = Object(this);
+
+      // 2. Let len be ? ToLength(? Get(O, "length")).
+      var len = o.length >>> 0;
+
+      // 3. If IsCallable(predicate) is false, throw a TypeError exception.
+      if (typeof predicate !== 'function') {
+        throw TypeError('predicate must be a function');
+      }
+
+      // 4. If thisArg was supplied, let T be thisArg; else let T be undefined.
+      var thisArg = arguments[1];
+
+      // 5. Let k be 0.
+      var k = 0;
+
+      // 6. Repeat, while k < len
+      while (k < len) {
+        // a. Let Pk be ! ToString(k).
+        // b. Let kValue be ? Get(O, Pk).
+        // c. Let testResult be ToBoolean(? Call(predicate, T, « kValue, k, O »)).
+        // d. If testResult is true, return kValue.
+        var kValue = o[k];
+        if (predicate.call(thisArg, kValue, k, o)) {
+          return kValue;
+        }
+        // e. Increase k by 1.
+        k++;
+      }
+
+      // 7. Return undefined.
+      return undefined;
+    },
+    configurable: true,
+    writable: true
+  });
+}


### PR DESCRIPTION
Object - Find method is not supported in the browser IE - 11. Fixed it by writing an alternate find method()