### PR TITLE
Make modules work from the playground

### DIFF
--- a/docassemble/jcc/abilitytopay/data/questions/interview.yml
+++ b/docassemble/jcc/abilitytopay/data/questions/interview.yml
@@ -1,9 +1,9 @@
 modules:
   - docassemble.base.util
-  - docassemble.jcc.abilitytopay.a2papi
-  - docassemble.jcc.abilitytopay.a2pdisplayutil
-  - docassemble.jcc.abilitytopay.translations
-  - docassemble.jcc.abilitytopay.templates
+  - .a2papi
+  - .a2pdisplayutil
+  - .translations
+  - .templates
 ---
 features:
   bootstrap theme: style.css


### PR DESCRIPTION
It's confusing when modifications to the playground modules have no effect.  When the modules are referenced in absolute reference (docassemble.jcc.abilitytopay), DocAssemble will use the modules outside the playground.
The relative references work in both playground and the "installed" version because it is relative to the environment.